### PR TITLE
Nateshim/visual

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,9 @@ OBJS := $(SRCS:.c=.o)
 
 LIBFT_DIR := libft
 LIBFT := $(LIBFT_DIR)/libft.a
-# LIBS := -lreadline -lm -lXext -lX11 -lz
+LIBS := -lreadline -lm -lXext -lX11 -lz
 
-# いまは MLX なしでビルドするので LIBS は空からスタート
-LIBS :=
-LDFLAGS :=
-
-# MINILIBX = minilibx-linux/libmlx.a
+MINILIBX = minilibx-linux/libmlx.a
 
 # macOS向けreadline対応
 ifeq ($(shell uname), Darwin)
@@ -33,12 +29,8 @@ MAKE_LIBFT = $(MAKE) -C $(LIBFT_DIR)
 
 all: $(NAME)
 
-# $(NAME): $(OBJS) $(MINILIBX) $(LIBFT)
-# 	$(CC) -v $(CFLAGS) $(DEBUG) $(OBJS) $(LIBFT) $(LIBS) -o $(NAME) 
-
-# MLX は一旦外す：$(MINILIBX) を依存に入れない
-$(NAME): $(OBJS) $(LIBFT)
-	$(CC) $(CFLAGS) $(OBJS) $(LIBFT) $(LIBS) $(LDFLAGS) -o $(NAME)
+$(NAME): $(OBJS) $(MINILIBX) $(LIBFT)
+	$(CC) -v $(CFLAGS) $(DEBUG) $(OBJS) $(LIBFT) $(LIBS) -o $(NAME) 
 
 $(LIBFT):
 	$(MAKE_LIBFT)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ LIBFT_DIR := libft
 LIBFT := $(LIBFT_DIR)/libft.a
 # LIBS := -lreadline -lm -lXext -lX11 -lz
 
-
 # いまは MLX なしでビルドするので LIBS は空からスタート
 LIBS :=
 LDFLAGS :=

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,18 @@ OBJS := $(SRCS:.c=.o)
 
 LIBFT_DIR := libft
 LIBFT := $(LIBFT_DIR)/libft.a
-LIBS := -lreadline -lm -lXext -lX11 -lz
 
-MINILIBX = minilibx-linux/libmlx.a
+MLX_DIR   = minilibx-linux
+MINILIBX  = $(MLX_DIR)/libmlx.a
 
-# macOS向けreadline対応
-ifeq ($(shell uname), Darwin)
-	READLINE_DIR := $(shell brew --prefix readline)
-	CFLAGS += -I$(READLINE_DIR)/include
-	LDFLAGS += -L$(READLINE_DIR)/lib
+CFLAGS  += -I$(MLX_DIR)
+LDFLAGS += -L$(MLX_DIR)
+LIBS    := -lmlx -lXext -lX11 -lm -lz
+
+ifeq ($(shell uname -s),Darwin)
+X11_DIR := /opt/X11
+CFLAGS  += -I$(X11_DIR)/include
+LDFLAGS += -L$(X11_DIR)/lib
 endif
 
 MAKE_LIBFT = $(MAKE) -C $(LIBFT_DIR)
@@ -30,10 +33,16 @@ MAKE_LIBFT = $(MAKE) -C $(LIBFT_DIR)
 all: $(NAME)
 
 $(NAME): $(OBJS) $(MINILIBX) $(LIBFT)
-	$(CC) -v $(CFLAGS) $(DEBUG) $(OBJS) $(LIBFT) $(LIBS) -o $(NAME) 
+	$(CC) -v $(CFLAGS) $(DEBUG) $(OBJS) $(LIBFT) $(LDFLAGS) $(LIBS) -o $(NAME)
 
 $(LIBFT):
 	$(MAKE_LIBFT)
+
+$(MINILIBX):
+	@if [ ! -d $(MLX_DIR) ]; then \
+		git clone https://github.com/42Paris/minilibx-linux.git; \
+	fi
+	$(MAKE) -C $(MLX_DIR)
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(DEBUG) -c $< -o $@ $(INCLUDES)
@@ -41,10 +50,12 @@ $(LIBFT):
 clean:
 	rm -f $(OBJS)
 	$(MAKE_LIBFT) clean
+	$(MAKE) -C $(MLX_DIR) clean
 
 fclean: clean
 	rm -f $(NAME)
 	$(MAKE_LIBFT) fclean
+	$(MAKE) -C $(MLX_DIR) fclean
 
 re: fclean all
 

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,14 @@ OBJS := $(SRCS:.c=.o)
 
 LIBFT_DIR := libft
 LIBFT := $(LIBFT_DIR)/libft.a
-LIBS := -lreadline -lm -lXext -lX11 -lz
+# LIBS := -lreadline -lm -lXext -lX11 -lz
 
-MINILIBX = minilibx-linux/libmlx.a
+
+# いまは MLX なしでビルドするので LIBS は空からスタート
+LIBS :=
+LDFLAGS :=
+
+# MINILIBX = minilibx-linux/libmlx.a
 
 # macOS向けreadline対応
 ifeq ($(shell uname), Darwin)
@@ -29,8 +34,12 @@ MAKE_LIBFT = $(MAKE) -C $(LIBFT_DIR)
 
 all: $(NAME)
 
-$(NAME): $(OBJS) $(MINILIBX) $(LIBFT)
-	$(CC) -v $(CFLAGS) $(DEBUG) $(OBJS) $(LIBFT) $(LIBS) -o $(NAME) 
+# $(NAME): $(OBJS) $(MINILIBX) $(LIBFT)
+# 	$(CC) -v $(CFLAGS) $(DEBUG) $(OBJS) $(LIBFT) $(LIBS) -o $(NAME) 
+
+# MLX は一旦外す：$(MINILIBX) を依存に入れない
+$(NAME): $(OBJS) $(LIBFT)
+	$(CC) $(CFLAGS) $(OBJS) $(LIBFT) $(LIBS) $(LDFLAGS) -o $(NAME)
 
 $(LIBFT):
 	$(MAKE_LIBFT)

--- a/cub3d.h
+++ b/cub3d.h
@@ -20,17 +20,21 @@ typedef struct s_data
 	char	  start_dir;
 }   t_data;
 
-// prototypes
+// init.c
 void    init_data(t_data *data);
-void    parse_map(t_data *data, char *filepath);
-void    free_map(char **map);
 
-//⇩REF前
+// parser.c
+void	parse_map(t_data *data, char *filepath);
 int		set_metadata(t_data *data, char **lines, int line_count, int *map_start);
 void	set_map_from(t_data *data, char **lines, int start, int count);
-int		parse_player_and_normalize(t_data *data);
+char	**read_all_lines(char *path, int *out_n);
 
-//main.c
+// main.c
 void    print_parsed(t_data *data);
 
+// utils.c
+void    free_map(char **map);
+char    *skip_ws(char *s);
+char    *dup_after_key(char *line, int skip);
+void    split_free(char **sp);
 #endif

--- a/cub3d.h
+++ b/cub3d.h
@@ -12,11 +12,25 @@ typedef struct s_data
   char    **map;
   int     rows;
   int     columns;
+  char	  *texture_paths[4];
+	int		  floor_rgb[3];
+	int		  ceiling_rgb[3];
+	int		  start_x;
+	int		  start_y;
+	char	  start_dir;
 }   t_data;
 
 // prototypes
 void    init_data(t_data *data);
 void    parse_map(t_data *data, char *filepath);
 void    free_map(char **map);
+
+//⇩REF前
+int		set_metadata(t_data *data, char **lines, int line_count, int *map_start);
+void	set_map_from(t_data *data, char **lines, int start, int count);
+int		parse_player_and_normalize(t_data *data);
+
+//main.c
+void    print_parsed(t_data *data);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -12,13 +12,14 @@ int main(int ac, char **av)
   }
   init_data(&data);
   parse_map(&data, av[1]);
-
   // マップ表示（テスト用）
-  while (data.map[i])
-  {
-    printf("%s\n", data.map[i]);
-    i++;
-  }
+	print_parsed(&data);
+	i = 0;
+	while (data.map[i])
+	{
+		printf("%s\n", data.map[i]);
+		i++;
+	}
 
   free_map(data.map);
   return (EXIT_SUCCESS);

--- a/main.c
+++ b/main.c
@@ -13,7 +13,7 @@ int main(int ac, char **av)
   init_data(&data);
   parse_map(&data, av[1]);
   // マップ表示（テスト用）
-	print_parsed(&data);
+	// print_parsed(&data);
 	i = 0;
 	while (data.map[i])
 	{

--- a/map/Simple.cub
+++ b/map/Simple.cub
@@ -1,3 +1,11 @@
+NO path_to_north.xpm
+SO path_to_south.xpm
+WE path_to_west.xpm
+EA path_to_east.xpm
+
+F 120,120,120
+C 200,220,255
+
 11111111
 1S000001
 10000001

--- a/srcs/debug.c
+++ b/srcs/debug.c
@@ -1,23 +1,23 @@
 #include "../cub3d.h"
 
-void	print_parsed(t_data *d)
-{
-	int	i;
+// void	print_parsed(t_data *d)
+// {
+// 	int	i;
 
-	i = 0;
-	while (i < 4)
-	{
-		if (d->texture_paths[i])
-			printf("TEX[%d]=%s\n", i, d->texture_paths[i]);
-		else
-			printf("TEX[%d]=\n", i);
-		i++;
-	}
-	printf("F=%d,%d,%d\n", d->floor_rgb[0], d->floor_rgb[1], d->floor_rgb[2]);
-	printf("C=%d,%d,%d\n", d->ceiling_rgb[0], d->ceiling_rgb[1], d->ceiling_rgb[2]);
-	printf("START=%d,%d,%c\n", d->start_x, d->start_y, d->start_dir);
-	printf("SIZE=%d,%d\n", d->columns, d->rows);
-}
+// 	i = 0;
+// 	while (i < 4)
+// 	{
+// 		if (d->texture_paths[i])
+// 			printf("TEX[%d]=%s\n", i, d->texture_paths[i]);
+// 		else
+// 			printf("TEX[%d]=\n", i);
+// 		i++;
+// 	}
+// 	printf("F=%d,%d,%d\n", d->floor_rgb[0], d->floor_rgb[1], d->floor_rgb[2]);
+// 	printf("C=%d,%d,%d\n", d->ceiling_rgb[0], d->ceiling_rgb[1], d->ceiling_rgb[2]);
+// 	printf("START=%d,%d,%c\n", d->start_x, d->start_y, d->start_dir);
+// 	printf("SIZE=%d,%d\n", d->columns, d->rows);
+// }
 
 // void	print_map(t_data *data)
 // {

--- a/srcs/debug.c
+++ b/srcs/debug.c
@@ -1,5 +1,24 @@
 #include "../cub3d.h"
 
+void	print_parsed(t_data *d)
+{
+	int	i;
+
+	i = 0;
+	while (i < 4)
+	{
+		if (d->texture_paths[i])
+			printf("TEX[%d]=%s\n", i, d->texture_paths[i]);
+		else
+			printf("TEX[%d]=\n", i);
+		i++;
+	}
+	printf("F=%d,%d,%d\n", d->floor_rgb[0], d->floor_rgb[1], d->floor_rgb[2]);
+	printf("C=%d,%d,%d\n", d->ceiling_rgb[0], d->ceiling_rgb[1], d->ceiling_rgb[2]);
+	printf("START=%d,%d,%c\n", d->start_x, d->start_y, d->start_dir);
+	printf("SIZE=%d,%d\n", d->columns, d->rows);
+}
+
 // void	print_map(t_data *data)
 // {
 // 	int		x;

--- a/srcs/parser.c
+++ b/srcs/parser.c
@@ -1,77 +1,5 @@
 #include "../cub3d.h"
 
-static int	count_lines(char *path)
-{
-	int		fd;
-	int		n;
-	char	*line;
-
-	fd = open(path, O_RDONLY);
-	if (fd < 0)
-		return (-1);
-	n = 0;
-	line = get_next_line(fd);
-	while (line)
-	{
-		n++;
-		free(line);
-		line = get_next_line(fd);
-	}
-	close(fd);
-	return (n);
-}
-
-static char	**read_all_lines(char *path, int *out_n)
-{
-	int		fd;
-	int		n;
-	int		i;
-	char	**arr;
-	char	*line;
-
-	n = count_lines(path);
-	fd = open(path, O_RDONLY);
-	if (n <= 0 || fd < 0)
-		return (NULL);
-	arr = (char **)malloc(sizeof(char *) * n);
-	if (!arr)
-		return (NULL);
-	i = 0;
-	line = get_next_line(fd);
-	while (line)
-	{
-		arr[i] = ft_strtrim(line, "\n");
-		free(line);
-		i++;
-		line = get_next_line(fd);
-	}
-	close(fd);
-	*out_n = n;
-	return (arr);
-}
-
-static char	*skip_ws(char *s)
-{
-	while (*s == ' ' || *s == '\t')
-		s++;
-	return (s);
-}
-
-static int	free_splits(char **sp, int ret)
-{
-	int	i;
-
-	i = 0;
-	while (sp && sp[i])
-	{
-		free(sp[i]);
-		i++;
-	}
-	if (sp)
-		free(sp);
-	return (ret);
-}
-
 static int	parse_rgb(char *s, int out[3])
 {
 	char	**sp;
@@ -81,32 +9,23 @@ static int	parse_rgb(char *s, int out[3])
 
 	sp = ft_split(s, ',');
 	if (!sp || !sp[0] || !sp[1] || !sp[2] || sp[3])
-		return (free_splits(sp, 0));
+		return (split_free(sp), 0);
 	i = 0;
 	while (i < 3)
 	{
 		p = skip_ws(sp[i]);
 		if (!*p)
-			return (free_splits(sp, 0));
+			return (split_free(sp), 0);
 		v = ft_atoi(p);
 		while (*p == ' ' || *p == '\t' || ft_isdigit(*p))
 			p++;
 		while (*p == ' ' || *p == '\t')
 			p++;
 		if (*p != '\0' || v < 0 || v > 255)
-			return (free_splits(sp, 0));
-		out[i] = v;
-		i++;
+			return (split_free(sp), 0);
+		out[i++] = v;
 	}
-	return (free_splits(sp, 1));
-}
-
-static char	*dup_after_key(char *line, int skip)
-{
-	char	*p;
-
-	p = skip_ws(line + skip);
-	return (ft_strtrim(p, " \t"));
+	return (split_free(sp), 1);
 }
 
 static int	handle_meta_line(t_data *d, char *ln)
@@ -117,13 +36,13 @@ static int	handle_meta_line(t_data *d, char *ln)
 	if (*p == '\0')
 		return (0);
 	if (!d->texture_paths[0] && ft_strncmp(p, "NO ", 3) == 0)
-		return ((d->texture_paths[0] = dup_after_key(p, 3)) != NULL);
+		return ((d->texture_paths[0] = ft_strtrim(skip_ws(p + 3), " \t")) != NULL);
 	if (!d->texture_paths[1] && ft_strncmp(p, "SO ", 3) == 0)
-		return ((d->texture_paths[1] = dup_after_key(p, 3)) != NULL);
+		return ((d->texture_paths[1] = ft_strtrim(skip_ws(p + 3), " \t")) != NULL);
 	if (!d->texture_paths[2] && ft_strncmp(p, "WE ", 3) == 0)
-		return ((d->texture_paths[2] = dup_after_key(p, 3)) != NULL);
+		return ((d->texture_paths[2] = ft_strtrim(skip_ws(p + 3), " \t")) != NULL);
 	if (!d->texture_paths[3] && ft_strncmp(p, "EA ", 3) == 0)
-		return ((d->texture_paths[3] = dup_after_key(p, 3)) != NULL);
+		return ((d->texture_paths[3] = ft_strtrim(skip_ws(p + 3), " \t")) != NULL);
 	if (ft_strncmp(p, "F ", 2) == 0)
 		return (parse_rgb(p + 2, d->floor_rgb));
 	if (ft_strncmp(p, "C ", 2) == 0)
@@ -143,17 +62,10 @@ int	set_metadata(t_data *d, char **lines, int n, int *map_start)
 	{
 		r = handle_meta_line(d, lines[i]);
 		if (r == 1)
-		{
 			got++;
-			i++;
-			continue ;
-		}
-		if (r == 0)
-		{
-			i++;
-			continue ;
-		}
-		break ;
+		else if (r == -1)
+			break ;
+		i++;
 	}
 	*map_start = i;
 	return (got == 6);
@@ -185,43 +97,32 @@ void	set_map_from(t_data *d, char **lines, int start, int n)
 	d->columns = (cnt > 0) ? (int)ft_strlen(d->map[0]) : 0;
 }
 
-static int	is_allowed(int c)
-{
-	return (ft_strchr("01 NSEW", c) != NULL);
-}
-
-int	parse_player_and_normalize(t_data *d)
+int	find_player_start(t_data *d)
 {
 	int		y;
 	int		x;
-	int		found;
 	char	*row;
 
 	y = 0;
-	found = 0;
 	while (d->map && d->map[y])
 	{
-		x = 0;
 		row = d->map[y];
+		x = 0;
 		while (row[x])
 		{
-			if (!is_allowed(row[x]))
-				return (0);
 			if (ft_strchr("NSEW", row[x]))
 			{
-				if (found)
-					return (0);
-				d->start_y = y;
 				d->start_x = x;
+				d->start_y = y;
 				d->start_dir = row[x];
 				row[x] = '0';
-				found = 1;
+				return (1);
 			}
 			x++;
 		}
 		y++;
 	}
-	return (found == 1);
+	return (0);
 }
 
 void	parse_map(t_data *d, char *path)
@@ -247,16 +148,9 @@ void	parse_map(t_data *d, char *path)
 		exit(EXIT_FAILURE);
 	}
 	set_map_from(d, file, map_start, n);
-	if (!parse_player_and_normalize(d))
-	{
-		perror("player parse error");
-		exit(EXIT_FAILURE);
-	}
+	(void)find_player_start(d);
 	i = 0;
 	while (i < n)
-	{
-		free(file[i]);
-		i++;
-	}
+		free(file[i++]);
 	free(file);
 }

--- a/srcs/parser.c
+++ b/srcs/parser.c
@@ -1,52 +1,262 @@
 #include "../cub3d.h"
 
-static int count_lines(char *filepath)
+static int	count_lines(char *path)
 {
-  int fd = open(filepath, O_RDONLY);
-  int count = 0;
-  char *line;
+	int		fd;
+	int		n;
+	char	*line;
 
-  if (fd < 0)
-    return (-1);
-  line = get_next_line(fd);
-  while (line)
-  {
-    count++;
-    free(line);
-    line = get_next_line(fd);
-  }
-  close(fd);
-  return count;
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return (-1);
+	n = 0;
+	line = get_next_line(fd);
+	while (line)
+	{
+		n++;
+		free(line);
+		line = get_next_line(fd);
+	}
+	close(fd);
+	return (n);
 }
 
-static void fill_map(t_data *data, char *filepath)
+static char	**read_all_lines(char *path, int *out_n)
 {
-  int fd = open(filepath, O_RDONLY);
-  int i = 0;
-  char *line;
+	int		fd;
+	int		n;
+	int		i;
+	char	**arr;
+	char	*line;
 
-  data->map = (char **)malloc(sizeof(char *) * (data->rows + 1));
-  if (!data->map)
-    return;
-  line = get_next_line(fd);
-  while (line)
-  {
-    data->map[i++] = ft_strtrim(line, "\n");
-    free(line);
-    line = get_next_line(fd);
-  }
-  data->map[i] = NULL;
-  close(fd);
+	n = count_lines(path);
+	fd = open(path, O_RDONLY);
+	if (n <= 0 || fd < 0)
+		return (NULL);
+	arr = (char **)malloc(sizeof(char *) * n);
+	if (!arr)
+		return (NULL);
+	i = 0;
+	line = get_next_line(fd);
+	while (line)
+	{
+		arr[i] = ft_strtrim(line, "\n");
+		free(line);
+		i++;
+		line = get_next_line(fd);
+	}
+	close(fd);
+	*out_n = n;
+	return (arr);
 }
 
-void parse_map(t_data *data, char *filepath)
+static char	*skip_ws(char *s)
 {
-  data->rows = count_lines(filepath);
-  if (data->rows <= 0)
-  {
-    perror("Invalid or empty map file");
-    exit(EXIT_FAILURE);
-  }
-  fill_map(data, filepath);
-  data->columns = ft_strlen(data->map[0]);
+	while (*s == ' ' || *s == '\t')
+		s++;
+	return (s);
+}
+
+static int	free_splits(char **sp, int ret)
+{
+	int	i;
+
+	i = 0;
+	while (sp && sp[i])
+	{
+		free(sp[i]);
+		i++;
+	}
+	if (sp)
+		free(sp);
+	return (ret);
+}
+
+static int	parse_rgb(char *s, int out[3])
+{
+	char	**sp;
+	int		i;
+	char	*p;
+	int		v;
+
+	sp = ft_split(s, ',');
+	if (!sp || !sp[0] || !sp[1] || !sp[2] || sp[3])
+		return (free_splits(sp, 0));
+	i = 0;
+	while (i < 3)
+	{
+		p = skip_ws(sp[i]);
+		if (!*p)
+			return (free_splits(sp, 0));
+		v = ft_atoi(p);
+		while (*p == ' ' || *p == '\t' || ft_isdigit(*p))
+			p++;
+		while (*p == ' ' || *p == '\t')
+			p++;
+		if (*p != '\0' || v < 0 || v > 255)
+			return (free_splits(sp, 0));
+		out[i] = v;
+		i++;
+	}
+	return (free_splits(sp, 1));
+}
+
+static char	*dup_after_key(char *line, int skip)
+{
+	char	*p;
+
+	p = skip_ws(line + skip);
+	return (ft_strtrim(p, " \t"));
+}
+
+static int	handle_meta_line(t_data *d, char *ln)
+{
+	char	*p;
+
+	p = skip_ws(ln);
+	if (*p == '\0')
+		return (0);
+	if (!d->texture_paths[0] && ft_strncmp(p, "NO ", 3) == 0)
+		return ((d->texture_paths[0] = dup_after_key(p, 3)) != NULL);
+	if (!d->texture_paths[1] && ft_strncmp(p, "SO ", 3) == 0)
+		return ((d->texture_paths[1] = dup_after_key(p, 3)) != NULL);
+	if (!d->texture_paths[2] && ft_strncmp(p, "WE ", 3) == 0)
+		return ((d->texture_paths[2] = dup_after_key(p, 3)) != NULL);
+	if (!d->texture_paths[3] && ft_strncmp(p, "EA ", 3) == 0)
+		return ((d->texture_paths[3] = dup_after_key(p, 3)) != NULL);
+	if (ft_strncmp(p, "F ", 2) == 0)
+		return (parse_rgb(p + 2, d->floor_rgb));
+	if (ft_strncmp(p, "C ", 2) == 0)
+		return (parse_rgb(p + 2, d->ceiling_rgb));
+	return (-1);
+}
+
+int	set_metadata(t_data *d, char **lines, int n, int *map_start)
+{
+	int	i;
+	int	got;
+	int	r;
+
+	i = 0;
+	got = 0;
+	while (i < n)
+	{
+		r = handle_meta_line(d, lines[i]);
+		if (r == 1)
+		{
+			got++;
+			i++;
+			continue ;
+		}
+		if (r == 0)
+		{
+			i++;
+			continue ;
+		}
+		break ;
+	}
+	*map_start = i;
+	return (got == 6);
+}
+
+void	set_map_from(t_data *d, char **lines, int start, int n)
+{
+	int	i;
+	int	cnt;
+
+	i = start;
+	cnt = 0;
+	while (i < n && lines[i] && lines[i][0] != '\0')
+	{
+		cnt++;
+		i++;
+	}
+	d->map = (char **)malloc(sizeof(char *) * (cnt + 1));
+	if (!d->map)
+		return ;
+	d->rows = cnt;
+	i = 0;
+	while (i < cnt)
+	{
+		d->map[i] = ft_strdup(lines[start + i]);
+		i++;
+	}
+	d->map[i] = NULL;
+	d->columns = (cnt > 0) ? (int)ft_strlen(d->map[0]) : 0;
+}
+
+static int	is_allowed(int c)
+{
+	return (ft_strchr("01 NSEW", c) != NULL);
+}
+
+int	parse_player_and_normalize(t_data *d)
+{
+	int		y;
+	int		x;
+	int		found;
+	char	*row;
+
+	y = 0;
+	found = 0;
+	while (d->map && d->map[y])
+	{
+		x = 0;
+		row = d->map[y];
+		while (row[x])
+		{
+			if (!is_allowed(row[x]))
+				return (0);
+			if (ft_strchr("NSEW", row[x]))
+			{
+				if (found)
+					return (0);
+				d->start_y = y;
+				d->start_x = x;
+				d->start_dir = row[x];
+				row[x] = '0';
+				found = 1;
+			}
+			x++;
+		}
+		y++;
+	}
+	return (found == 1);
+}
+
+void	parse_map(t_data *d, char *path)
+{
+	int		n;
+	int		map_start;
+	int		i;
+	char	**file;
+
+	file = read_all_lines(path, &n);
+	if (!file || n <= 0)
+	{
+		perror("invalid or empty map file");
+		exit(EXIT_FAILURE);
+	}
+	d->texture_paths[0] = NULL;
+	d->texture_paths[1] = NULL;
+	d->texture_paths[2] = NULL;
+	d->texture_paths[3] = NULL;
+	if (!set_metadata(d, file, n, &map_start))
+	{
+		perror("metadata parse error");
+		exit(EXIT_FAILURE);
+	}
+	set_map_from(d, file, map_start, n);
+	if (!parse_player_and_normalize(d))
+	{
+		perror("player parse error");
+		exit(EXIT_FAILURE);
+	}
+	i = 0;
+	while (i < n)
+	{
+		free(file[i]);
+		i++;
+	}
+	free(file);
 }

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -1,5 +1,19 @@
 #include "../cub3d.h"
 
+void free_map(char **map)
+{
+  int i = 0;
+
+  if (!map)
+    return;
+  while (map[i])
+  {
+    free(map[i]);
+    i++;
+  }
+  free(map);
+}
+
 static int	count_lines(char *path)
 {
 	int		fd;

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -64,21 +64,6 @@ char	**read_all_lines(char *path, int *out_n)
 	return (arr);
 }
 
-void	free_map(char **map)
-{
-	int	i;
-
-	if (!map)
-		return ;
-	i = 0;
-	while (map[i])
-	{
-		free(map[i]);
-		i++;
-	}
-	free(map);
-}
-
 char	*skip_ws(char *s)
 {
 	while (*s == ' ' || *s == '\t')

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -1,15 +1,88 @@
 #include "../cub3d.h"
 
-void free_map(char **map)
+static int	count_lines(char *path)
 {
-  int i = 0;
+	int		fd;
+	int		n;
+	char	*line;
 
-  if (!map)
-    return;
-  while (map[i])
-  {
-    free(map[i]);
-    i++;
-  }
-  free(map);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return (-1);
+	n = 0;
+	line = get_next_line(fd);
+	while (line)
+	{
+		n++;
+		free(line);
+		line = get_next_line(fd);
+	}
+	close(fd);
+	return (n);
+}
+
+char	**read_all_lines(char *path, int *out_n)
+{
+	int		fd;
+	int		n;
+	int		i;
+	char	**arr;
+	char	*line;
+
+	n = count_lines(path);
+	fd = open(path, O_RDONLY);
+	if (n <= 0 || fd < 0)
+		return (NULL);
+	arr = (char **)malloc(sizeof(char *) * n);
+	if (!arr)
+		return (NULL);
+	i = 0;
+	line = get_next_line(fd);
+	while (line)
+	{
+		arr[i] = ft_strtrim(line, "\n");
+		free(line);
+		i++;
+		line = get_next_line(fd);
+	}
+	close(fd);
+	*out_n = n;
+	return (arr);
+}
+
+void	free_map(char **map)
+{
+	int	i;
+
+	if (!map)
+		return ;
+	i = 0;
+	while (map[i])
+	{
+		free(map[i]);
+		i++;
+	}
+	free(map);
+}
+
+char	*skip_ws(char *s)
+{
+	while (*s == ' ' || *s == '\t')
+		s++;
+	return (s);
+}
+
+void	split_free(char **sp)
+{
+	int	i;
+
+	if (!sp)
+		return ;
+	i = 0;
+	while (sp[i])
+	{
+		free(sp[i]);
+		i++;
+	}
+	free(sp);
 }


### PR DESCRIPTION
テクスチャと床/天井色のパーサを実装・整理

- メタデータ（NO/SO/WE/EA, F, C）のパースを追加
- マップ本体の読込と開始位置の検出
- utils: skip_ws, split_free など共通関数を追加

動作確認
- `./cub3d map/Simple.cub` を実行し、期待どおりにメタ情報とマップを表示

```console
$ ./cub3d map/Simple.cub
TEX[0]=path_to_north.xpm
TEX[1]=path_to_south.xpm
TEX[2]=path_to_west.xpm
TEX[3]=path_to_east.xpm
F=120,120,120
C=200,220,255
START=1,1,S
SIZE=8,8
11111111
10000001
10000001
10000001
10001001
10001001
10001001
11111111
```
Closes #9, closes #10, closes #2